### PR TITLE
Fix digest auth bug & update readme about enabling https

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,18 @@
 [![verified-by-homebridge](https://badgen.net/badge/homebridge/verified/purple)](https://github.com/homebridge/homebridge/wiki/Verified-Plugins) [![npm version](https://badge.fury.io/js/homebridge-dahua-alerts.svg)](https://www.npmjs.com/package/homebridge-dahua-alerts) [![npm total downloads](https://img.shields.io/npm/dt/homebridge-dahua-alerts.svg)](https://www.npmjs.com/package/homebridge-dahua-alerts)
 
 
-Routes motion alerts for Dahua and Lorex camera streams to homebridge-camera-ffmpeg 
+Routes motion alerts for Dahua and Lorex camera streams to homebridge-camera-ffmpeg
 
--- Confirmed working with: Lorex: LHV1004 DHV & Dahua: DHI-HCVR4116HS-S3, DH-XVR5116HS-X, DH-IPC-HDBW4631R-S, DHI-NVR4104HS-P-4Ks2 but lots of Dahua/Lorex NVRs and standalone cameras share this VideoMotion api.
+-- Confirmed working with: 
+| Dahua DVR | Dahua Standalone Camera | Lorex DVR |
+| - | - | - |
+| - | -| LHV1004 DHV |
+| DHI-HCVR4116HS-S3 | - | - |
+| DH-XVR5116HS-X | - | - | 
+| - | DH-IPC-HDBW4631R-S | - | 
+| DHI-NVR4104HS-P-4Ks2 | - | - |
+| - | - | Lorex NR818 |
+but lots of Dahua/Lorex NVRs and standalone cameras share this VideoMotion api.
 
 Like this plugin? -> [Buy me a ☕coffee☕](https://www.buymeacoffee.com/kusha)
 
@@ -15,6 +24,7 @@ Like this plugin? -> [Buy me a ☕coffee☕](https://www.buymeacoffee.com/kusha)
 3. Configure your RTSP streams in `homebridge-camera-ffmpeg` and configure [`Http-based Automation`](https://sunoo.github.io/homebridge-camera-ffmpeg/automation/http.html) for the camera streams you want motion detection. Make sure to set `motionTimeout` to 0 and set HTTP Localhost Only to true.
 4. Install [`homebridge-dahua-alerts`](https://www.npmjs.com/package/homebridge-dahua-alerts).
 5. Configure your NVR and camera settings.
+    - Ensure you have enabled `https` or enabled port 443 on your device if you're getting `ECONNREFUSED` in the debug logs. Not required by all.
 
 ## Sample config.json
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Like this plugin? -> [Buy me a ☕coffee☕](https://www.buymeacoffee.com/kusha)
 3. Configure your RTSP streams in `homebridge-camera-ffmpeg` and configure [`Http-based Automation`](https://sunoo.github.io/homebridge-camera-ffmpeg/automation/http.html) for the camera streams you want motion detection. Make sure to set `motionTimeout` to 0 and set HTTP Localhost Only to true.
 4. Install [`homebridge-dahua-alerts`](https://www.npmjs.com/package/homebridge-dahua-alerts).
 5. Configure your NVR and camera settings.
-    - Ensure you have enabled `https` or enabled port 443 on your device if you're getting `ECONNREFUSED` in the debug logs. Not required by all.
+    - Ensure you have enabled `https` or port 443 on your device if you're getting `ECONNREFUSED` in the debug logs. Not required by all.
 
 ## Sample config.json
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-dahua-alerts",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-dahua-alerts",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Routes motion alerts for Dahua and Lorex camera streams to `homebridge-camera-ffmpeg`",
   "main": "dist/index.js",
   "dependencies": {


### PR DESCRIPTION
Digest auth header was not being de-serialized properly, fixed with regex string split that accounts for potential white-spaces before and after the comma.
Also added better error logging against digest auth issues.
Updated readme with list of confirmed cameras working with plugin.